### PR TITLE
Add formatting and const removal usecases

### DIFF
--- a/bin/gobabel.dart
+++ b/bin/gobabel.dart
@@ -7,6 +7,7 @@ import 'package:gobabel/src/gobabel_controller.dart';
 import 'package:gobabel/src/scripts/analyse_already_used_babel_labels/resolve_already_existing_key.dart';
 import 'package:gobabel/src/scripts/analyse_codebase_related/analyse_codebase_issue_integrity.dart';
 import 'package:gobabel/src/scripts/analyse_codebase_related/move_hardcoded_string_param_case.dart';
+import 'package:gobabel/src/scripts/analyse_codebase_related/remove_const_keyword_usecase.dart';
 import 'package:gobabel/src/scripts/analyse_codebase_related/resolve_all_hardcoded_strings_usecase.dart';
 import 'package:gobabel/src/scripts/arb_migration_related/ensure_integrity_of_arb.dart';
 import 'package:gobabel/src/scripts/arb_migration_related/extract_location_data_from_arb_file_name.dart';
@@ -22,6 +23,7 @@ import 'package:gobabel/src/scripts/git_related/get_git_user.dart';
 import 'package:gobabel/src/scripts/git_related/get_last_local_commit_in_current_branch.dart';
 import 'package:gobabel/src/scripts/git_related/get_project_origin.dart';
 import 'package:gobabel/src/scripts/git_related/set_changed_files_between_commits.dart';
+import 'package:gobabel/src/scripts/other/dart_fix_format_usecase.dart';
 import 'package:gobabel/src/scripts/translation_related/get_hardcoded_string_key_cache.dart';
 import 'package:gobabel/src/scripts/translation_related/translate_new_strings_arb.dart';
 import 'package:gobabel_client/gobabel_client.dart';
@@ -133,6 +135,8 @@ Future<void> main(List<String> arguments) async {
       getAllCommitsInCurrentGitTreeOrdoredByTime:
           GetAllCommitsInCurrentGitTreeOrdoredByTime(),
     ),
+    removeConstKeywordUsecase: RemoveConstKeywordUsecase(),
+    dartFixFormatUsecase: DartFixFormatUsecase(),
   );
 
   // Parse the arguments

--- a/lib/src/scripts/analyse_codebase_related/remove_const_keyword_usecase.dart
+++ b/lib/src/scripts/analyse_codebase_related/remove_const_keyword_usecase.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:meta/meta.dart';
+import 'package:gobabel/src/core/dependencies.dart';
+
+class RemoveConstKeywordUsecase {
+  Future<void> call() async {
+    final List<File> files = await Dependencies.filesToBeAnalysed;
+    if (files.isEmpty) return;
+
+    for (final file in files) {
+      final source = await file.readAsString();
+      final transformed = _removeConsts(source);
+      if (transformed != source) {
+        await file.writeAsString(transformed);
+      }
+    }
+  }
+
+  @visibleForTesting
+  String _removeConsts(String source) {
+    final parseResult = parseString(
+      content: source,
+      featureSet: FeatureSet.latestLanguageVersion(),
+      throwIfDiagnostics: false,
+    );
+
+    Token? token = parseResult.unit.beginToken;
+    final ranges = <_Range>[];
+    while (token.type != TokenType.EOF) {
+      if (token.lexeme == 'const') {
+        ranges.add(_Range(start: token.offset, end: token.end));
+      }
+      token = token.next!;
+    }
+
+    var result = source;
+    for (final range in ranges.reversed) {
+      result = result.replaceRange(range.start, range.end, '');
+    }
+    return result;
+  }
+}
+
+class _Range {
+  final int start;
+  final int end;
+  _Range({required this.start, required this.end});
+}

--- a/lib/src/scripts/analyse_codebase_related/remove_const_keyword_usecase.dart
+++ b/lib/src/scripts/analyse_codebase_related/remove_const_keyword_usecase.dart
@@ -13,7 +13,7 @@ class RemoveConstKeywordUsecase {
 
     for (final file in files) {
       final source = await file.readAsString();
-      final transformed = _removeConsts(source);
+      final transformed = removeConsts(source);
       if (transformed != source) {
         await file.writeAsString(transformed);
       }
@@ -21,7 +21,7 @@ class RemoveConstKeywordUsecase {
   }
 
   @visibleForTesting
-  String _removeConsts(String source) {
+  String removeConsts(String source) {
     final parseResult = parseString(
       content: source,
       featureSet: FeatureSet.latestLanguageVersion(),
@@ -30,11 +30,24 @@ class RemoveConstKeywordUsecase {
 
     Token? token = parseResult.unit.beginToken;
     final ranges = <_Range>[];
-    while (token.type != TokenType.EOF) {
+
+    while (token != null && token.type != TokenType.EOF) {
       if (token.lexeme == 'const') {
-        ranges.add(_Range(start: token.offset, end: token.end));
+        // Check if this const is followed by a constructor call
+        // Skip whitespace and comments to find the next meaningful token
+        Token? nextToken = token.next;
+        while (nextToken != null &&
+            (nextToken.type == TokenType.SINGLE_LINE_COMMENT ||
+                nextToken.type == TokenType.MULTI_LINE_COMMENT ||
+                nextToken.lexeme.trim().isEmpty)) {
+          nextToken = nextToken.next;
+        }
+
+        if (nextToken != null && _isConstructorCall(nextToken, source)) {
+          ranges.add(_Range(start: token.offset, end: token.end));
+        }
       }
-      token = token.next!;
+      token = token.next;
     }
 
     var result = source;
@@ -42,6 +55,87 @@ class RemoveConstKeywordUsecase {
       result = result.replaceRange(range.start, range.end, '');
     }
     return result;
+  }
+
+  bool _isConstructorCall(Token token, String source) {
+    // Direct collection literals: const [] or const {}
+    if (token.type == TokenType.OPEN_SQUARE_BRACKET ||
+        token.type == TokenType.OPEN_CURLY_BRACKET) {
+      return true;
+    }
+
+    // Generic collection: const <Type>[] or const <Type>{}
+    if (token.type == TokenType.LT) {
+      return true;
+    }
+
+    // Check if this looks like a constructor call (identifier followed by parenthesis)
+    if (token.type == TokenType.IDENTIFIER) {
+      Token? nextToken = token.next;
+
+      // Skip whitespace
+      while (nextToken != null && nextToken.lexeme.trim().isEmpty) {
+        nextToken = nextToken.next;
+      }
+
+      if (nextToken != null) {
+        // Direct constructor call: const Widget()
+        if (nextToken.type == TokenType.OPEN_PAREN) {
+          return true;
+        }
+
+        // Generic constructor call: const Widget<T>()
+        if (nextToken.type == TokenType.LT) {
+          return true;
+        }
+
+        // Collection literals after identifier: const Widget[] or const Widget{}
+        if (nextToken.type == TokenType.OPEN_SQUARE_BRACKET ||
+            nextToken.type == TokenType.OPEN_CURLY_BRACKET) {
+          return true;
+        }
+        
+        // Check if this is a type declaration (variable declaration)
+        // If we find another identifier after the first one, it's likely a variable declaration
+        // e.g., "const Map<String, int> variableName = ..."
+        if (nextToken.type == TokenType.LT) {
+          // Skip through generic type parameters to find what comes after
+          Token? afterGeneric = _skipGenericTypes(nextToken);
+          if (afterGeneric != null && afterGeneric.type == TokenType.IDENTIFIER) {
+            // This looks like: const Type<Generic> variableName
+            return false; // This is a variable declaration
+          }
+        } else if (nextToken.type == TokenType.IDENTIFIER) {
+          // This looks like: const Type variableName
+          return false; // This is a variable declaration
+        }
+      }
+    }
+
+    return false;
+  }
+  
+  Token? _skipGenericTypes(Token startToken) {
+    if (startToken.type != TokenType.LT) return startToken;
+    
+    Token? current = startToken.next;
+    int depth = 1;
+    
+    while (current != null && depth > 0) {
+      if (current.type == TokenType.LT) {
+        depth++;
+      } else if (current.type == TokenType.GT) {
+        depth--;
+      }
+      current = current.next;
+    }
+    
+    // Skip whitespace after closing >
+    while (current != null && current.lexeme.trim().isEmpty) {
+      current = current.next;
+    }
+    
+    return current;
   }
 }
 

--- a/lib/src/scripts/other/dart_fix_format_usecase.dart
+++ b/lib/src/scripts/other/dart_fix_format_usecase.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:gobabel/src/core/dependencies.dart';
+import 'package:gobabel/src/core/utils/git_process_runner.dart';
+
+class DartFixFormatUsecase {
+  Future<void> call() async {
+    final List<File> files = await Dependencies.filesToBeAnalysed;
+    if (files.isEmpty) return;
+
+    final String paths = files.map((e) => '"${e.path}"').join(' ');
+
+    await BabelProcessRunner.run('dart fix --apply $paths');
+    await BabelProcessRunner.run('dart format $paths');
+  }
+}

--- a/test/src/scripts/analyse_codebase_related/remove_const_keyword_usecase_test.dart
+++ b/test/src/scripts/analyse_codebase_related/remove_const_keyword_usecase_test.dart
@@ -1,0 +1,220 @@
+import 'package:test/test.dart';
+import 'package:gobabel/src/scripts/analyse_codebase_related/remove_const_keyword_usecase.dart';
+
+void main() {
+  late RemoveConstKeywordUsecase usecase;
+
+  setUp(() {
+    usecase = RemoveConstKeywordUsecase();
+  });
+
+  group('RemoveConstKeywordUsecase', () {
+    group('removeConsts', () {
+      test('should NOT remove const from variable declarations', () {
+        const input = '''
+const int number = 42;
+const String text = 'hello';
+const double pi = 3.14;
+static const String constantString = 'test';
+''';
+
+        final result = usecase.removeConsts(input);
+        expect(result, equals(input)); // Should remain unchanged
+      });
+
+      test('should remove const from constructor calls', () {
+        const input = '''
+final widget = const Text('Hello');
+final container = const Container(child: const Text('World'));
+''';
+        const expected = '''
+final widget =  Text('Hello');
+final container =  Container(child:  Text('World'));
+''';
+
+        final result = usecase.removeConsts(input);
+        expect(result, equals(expected));
+      });
+
+      test(
+        'should remove const from collections but not variable declarations',
+        () {
+          const input = '''
+const list = const [1, 2, 3];
+const map = const {'key': 'value'};
+const set = const {1, 2, 3};
+''';
+          const expected = '''
+const list =  [1, 2, 3];
+const map =  {'key': 'value'};
+const set =  {1, 2, 3};
+''';
+
+          final result = usecase.removeConsts(input);
+          expect(result, equals(expected));
+        },
+      );
+
+      test('should NOT remove const from strings', () {
+        const input = '''
+const message = 'This const should stay';
+final text = "Another const in string";
+final multiline = """
+This const keyword should remain
+const values are important
+""";
+''';
+
+        final result = usecase.removeConsts(input);
+        expect(result, equals(input)); // Should remain unchanged
+      });
+
+      test('should handle mixed scenarios correctly', () {
+        const input = '''
+class MyClass {
+  const MyClass();
+  
+  static const String constantString = 'const in string should stay';
+  static const int number = 42;
+  
+  Widget build() {
+    return const Column(
+      children: const [
+        const Text('Hello const world'),
+        const SizedBox(height: 10),
+      ],
+    );
+  }
+}
+''';
+        const expected = '''
+class MyClass {
+   MyClass();
+  
+  static const String constantString = 'const in string should stay';
+  static const int number = 42;
+  
+  Widget build() {
+    return  Column(
+      children:  [
+         Text('Hello const world'),
+         SizedBox(height: 10),
+      ],
+    );
+  }
+}
+''';
+
+        final result = usecase.removeConsts(input);
+        expect(result, equals(expected));
+      });
+
+      test('should handle const with generics in constructor calls', () {
+        const input = '''
+const Map<String, int> scores = const <String, int>{'a': 1, 'b': 2};
+const List<Widget> widgets = const <Widget>[const Text('test')];
+''';
+        const expected = '''
+const Map<String, int> scores =  <String, int>{'a': 1, 'b': 2};
+const List<Widget> widgets =  <Widget>[ Text('test')];
+''';
+
+        final result = usecase.removeConsts(input);
+        expect(result, equals(expected));
+      });
+
+      test(
+        'should return same string when no constructor const keywords present',
+        () {
+          const input = '''
+int number = 42;
+String text = 'hello';
+final widget = Text('Hello World');
+const int staticValue = 100;
+''';
+
+          final result = usecase.removeConsts(input);
+          expect(result, equals(input));
+        },
+      );
+
+      test('should handle empty string', () {
+        const input = '';
+        final result = usecase.removeConsts(input);
+        expect(result, equals(''));
+      });
+
+      test('should not remove standalone const keyword if not constructor', () {
+        const input = 'const int value = 5;';
+
+        final result = usecase.removeConsts(input);
+        expect(result, equals(input)); // Should remain unchanged
+      });
+
+      test(
+        'should preserve const in variable declarations but remove from constructors',
+        () {
+          const input = '''
+// Variable declarations should keep const
+const int value = 42; 
+static const String name = 'test';
+final const double pi = 3.14;
+
+// Constructor calls should lose const
+Widget build() {
+  return const Scaffold(
+    body: const Center(
+      child: const Column(
+        children: const [
+          const Text('Hello'),
+          const SizedBox(height: 8),
+        ],
+      ),
+    ),
+  );
+}
+''';
+          const expected = '''
+// Variable declarations should keep const
+const int value = 42; 
+static const String name = 'test';
+final const double pi = 3.14;
+
+// Constructor calls should lose const
+Widget build() {
+  return  Scaffold(
+    body:  Center(
+      child:  Column(
+        children:  [
+           Text('Hello'),
+           SizedBox(height: 8),
+        ],
+      ),
+    ),
+  );
+}
+''';
+
+          final result = usecase.removeConsts(input);
+          expect(result, equals(expected));
+        },
+      );
+
+      test('should handle const constructors with named parameters', () {
+        const input = '''const Padding(
+  padding: const EdgeInsets.all(8.0),
+  child: const Text('Hello'),
+)
+''';
+        const expected = ''' Padding(
+  padding: const EdgeInsets.all(8.0),
+  child:  Text('Hello'),
+)
+''';
+
+        final result = usecase.removeConsts(input);
+        expect(result, equals(expected));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `DartFixFormatUsecase` to run `dart fix --apply` and `dart format`
- add `RemoveConstKeywordUsecase` to remove `const` keywords via analyzer

## Testing
- `dart pub get` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845f7200d148331b8bf283ef7f33d75